### PR TITLE
Fix private endpoint creation when made before private link scoped service

### DIFF
--- a/resources.azure.monitor.private.endpoints.tf
+++ b/resources.azure.monitor.private.endpoints.tf
@@ -21,6 +21,8 @@ resource "azurerm_private_endpoint" "ampls" {
     private_connection_resource_id = var.azurerm_monitor_private_link_scope_id == null ? join("", azurerm_monitor_private_link_scope.main.*.id) : var.azurerm_monitor_private_link_scope_id
     subresource_names              = ["azuremonitor"]
   }
+
+  depends_on = [ azurerm_monitor_private_link_scoped_service.main ]
 }
 
 


### PR DESCRIPTION
## Describe your changes

There is a hidden dependency between `azurerm_private_endpoint.ampls` and `azurerm_monitor_private_link_scoped_service.main`, which can cause the private endpoint to fail to create if it is made before the private link scoped service is finished creating.

This causes the private endpoint to fail to create with the error:

```
{"status":"Failed","error":{"code":"BadRequest","message":"Call to Microsoft.Insights/privateLinkScopes failed. Error message: Mismatching RequiredMembers in Request","details":[]}}
```

Adding an explicit depends_on will ensure the private endpoint is always made after the private link scoped service

## Issue number

fixes #18 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

